### PR TITLE
Add user as json to cookie on signin instead of only user id

### DIFF
--- a/evento/src/views/MyEvents/MyEvents.test.js
+++ b/evento/src/views/MyEvents/MyEvents.test.js
@@ -7,15 +7,15 @@ import { mount } from 'enzyme';
 import MyEvents from './';
 
 const eventMocks = Mock.generateEvents(5);
+const userMock = Mock.generateUser();
 
-const UserID = 5;
 const UserAuthToken = "token_token";
-const setCookies = (userID = UserID, userAuthToken = UserAuthToken) => {
-	Cookie.set("userId", userID);
+const setCookies = (user = userMock, userAuthToken = UserAuthToken) => {
+	Cookie.set("user", user);
 	Cookie.set("auth_token", userAuthToken);
 };
 
-fetchMock.get(`/users/${UserID}/events`, (url, opts) => {
+fetchMock.get(`/users/${userMock.id}/events`, (url, opts) => {
 	if(!opts.headers || opts.headers.Authorization !== UserAuthToken) {
 		return { throws: 401 };
 	}
@@ -29,7 +29,7 @@ it('renders without crashing', () => {
 });
 
 it('shows error if user is not logged in', async () => {
-	Cookie.remove("userId");
+	Cookie.remove("user");
 	Cookie.remove("auth_token");
 
 	const myEventsPage = mount(<MyEvents />);
@@ -39,7 +39,7 @@ it('shows error if user is not logged in', async () => {
 });
 
 it('shows error if given incorrect parameters', async () => {
-	setCookies(UserID, "wrong_auth_token");
+	setCookies(userMock, "wrong_auth_token");
 
 	const myEventsPage = mount(<MyEvents />);
 	await waitForFetches();

--- a/evento/src/views/MyEvents/index.js
+++ b/evento/src/views/MyEvents/index.js
@@ -17,16 +17,18 @@ class MyEvents extends Component {
 	}
 	
 	fetchEvents() {
-		const userId = Cookie.get('userId');
+		let user = Cookie.get('user');
 		const authToken = Cookie.get('auth_token');
 
 		// If userId or authToken is not found do try to fetch events
-		if (!userId || !authToken) {
+		if (!user || !authToken) {
 			this.setState({ errorMessage: "You are not logged in. Please login again"});
 			return;
 		}
 
-		fetch(`/users/${userId}/events`, { headers: { 'Authorization': authToken }})
+		user = JSON.parse(user); // Parse user to usable form
+
+		fetch(`/users/${user.id}/events`, { headers: { 'Authorization': authToken }})
 		.then(response => response.json())
 		.then(events => this.setState({ events: events }))
 		.catch(() => this.setState({ errorMessage: "Something went wrong" }));

--- a/evento/src/views/MyEvents/index.js
+++ b/evento/src/views/MyEvents/index.js
@@ -17,16 +17,16 @@ class MyEvents extends Component {
 	}
 	
 	fetchEvents() {
-		let user = Cookie.get('user');
+		const userCookie = Cookie.get('user');
 		const authToken = Cookie.get('auth_token');
 
-		// If userId or authToken is not found do try to fetch events
-		if (!user || !authToken) {
+		// If userCookie or authToken is not found do try to fetch events
+		if (!userCookie || !authToken) {
 			this.setState({ errorMessage: "You are not logged in. Please login again"});
 			return;
 		}
 
-		user = JSON.parse(user); // Parse user to usable form
+		const user = JSON.parse(userCookie); // Parse user to usable form
 
 		fetch(`/users/${user.id}/events`, { headers: { 'Authorization': authToken }})
 		.then(response => response.json())

--- a/evento/src/views/SignInPage/SignInPage.test.js
+++ b/evento/src/views/SignInPage/SignInPage.test.js
@@ -100,8 +100,8 @@ describe('SignInPage', () => {
 		it('sets auth_token and userId cookies on successiful fetch', async () => {
 			const [signInPage, AUTH_TOKEN, USER] = await successifulSignIn();
 
-			expect(Cookie.get('auth_token')).toEqual(AUTH_TOKEN);
-			expect(Cookie.get('userId')).toEqual(USER.id.toString()); // Cookies are stored as strings
+			expect(Cookie.get('auth_token')).toEqual(AUTH_TOKEN)
+			expect(JSON.parse(Cookie.get('user')).id).toEqual(USER.id); // Cookies are stored as strings
 		});
 
 		it('sets error message on failed fetch', async () => {
@@ -109,7 +109,7 @@ describe('SignInPage', () => {
 
 			expect(signInPage.state('errorMessage')).toBe('Invalid credentials');
 			expect(Cookie.get('auth_token')).toBeUndefined();
-			expect(Cookie.get('userId')).toBeUndefined();
+			expect(Cookie.get('user')).toBeUndefined();
 		});
 
 		it('redirects to front page after successiful sign in', async () => {

--- a/evento/src/views/SignInPage/index.js
+++ b/evento/src/views/SignInPage/index.js
@@ -30,9 +30,9 @@ class SignInPage extends Component {
 				return Promise.reject('Invalid credentials');
 			}
 		})
-		.then(authKey => {
-			Cookie.set('auth_token', authKey.auth_token);
-			Cookie.set('userId', authKey.user.id)
+		.then(json => {
+			Cookie.set('auth_token', json.auth_token);
+			Cookie.set('user', JSON.stringify(json.user))
 
 			// Move to front page after successiful sign in
 			this.props.history.push('/')


### PR DESCRIPTION
Since `/authenticate` return whole user object, it should be stored to `user` cookie. This reduces future fetches.